### PR TITLE
fixed mobile size spinner

### DIFF
--- a/assets/css/detail.css
+++ b/assets/css/detail.css
@@ -1979,10 +1979,9 @@ ul{
     }
 
     .center-and-right {
-    overflow-y: visible !important;
-    height: auto !important;
-    max-height: none !important;
-    -webkit-overflow-scrolling: touch; /* iOS対策 */
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
     }
     /* Chrome, Safari */
     .center-and-right::-webkit-scrollbar {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2979,10 +2979,12 @@ ul{
     }
 
     .center-and-right {
-    overflow-y: visible !important;
-    height: auto !important;
-    max-height: none !important;
-    -webkit-overflow-scrolling: touch; /* iOS対策 */
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    }
+    .center-and-right::-webkit-scrollbar {
+    display: none;
     }
     /* Chrome, Safari */
     .center-and-right::-webkit-scrollbar {

--- a/assets/css/new-styles.css
+++ b/assets/css/new-styles.css
@@ -4605,10 +4605,9 @@ ul{
     }
 
     .center-and-right {
-    overflow-y: visible !important;
-    height: auto !important;
-    max-height: none !important;
-    -webkit-overflow-scrolling: touch; /* iOS対策 */
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
     }
     /* Chrome, Safari */
     .center-and-right::-webkit-scrollbar {

--- a/assets/css/users-detail.css
+++ b/assets/css/users-detail.css
@@ -1770,10 +1770,9 @@ ul{
     }
 
     .center-and-right {
-    overflow-y: visible !important;
-    height: auto !important;
-    max-height: none !important;
-    -webkit-overflow-scrolling: touch; /* iOS対策 */
+    overflow-y: auto !important;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
     }
     /* Chrome, Safari */
     .center-and-right::-webkit-scrollbar {


### PR DESCRIPTION
-     overflow-y: auto !important; /* ← visibleにしない */
- これでspinnerがスマホsize時に無限に回り続けるのを回避しました。