### PR TITLE
Django update or delete psycopg2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ cryptography==44.0.1
 decorator==4.4.2
 defusedxml==0.6.0
 dj-database-url==0.5.0
-Django==4.2.24
+Django==4.2.25
 django-ckeditor==5.7.0
 django-cleanup==9.0.0
 django-crispy-forms==1.7.2
@@ -36,7 +36,6 @@ pillow==10.3.0
 pillow_heif==0.18.0
 pipdeptree==2.27.0
 proglog==0.1.12
-psycopg2==2.9.10
 psycopg2-binary==2.9.9
 pycparser==2.20
 PyJWT==2.9.0


### PR DESCRIPTION
Django を updateしました。

requirements.txtからpsycopg2==2.9.10を削除
